### PR TITLE
feat: creation of releases only at master

### DIFF
--- a/.github/workflows/django.yml
+++ b/.github/workflows/django.yml
@@ -6,9 +6,10 @@ on:
       - develop
       - master
       - epic
-  release:
-    types:
-      - created
+  workflow_call:
+    secrets:
+      CODACY_PROJECT_TOKEN:
+        required: true
 
 jobs:
   build:
@@ -59,18 +60,3 @@ jobs:
       with:
           project-token: ${{secrets.CODACY_PROJECT_TOKEN}}
           coverage-reports: decide/coverage.xml
-
-  release:
-    runs-on: ubuntu-latest
-    needs: build
-    steps:
-    - name: Checkout code
-      uses: actions/checkout@v3
-      
-    - name: Set up Python ${{matrix.python-version}}
-      uses: actions/setup-python@v4
-      with:
-        python-version: ${{matrix.python-version}}
-        
-    - name: Install dependencies
-      run: python -m pip install --upgrade pip 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,24 @@
+name: release
+
+on:
+  push: 
+    tags:
+      - '*'
+
+permissions:
+  contents: write
+
+jobs:
+  buildTest:
+    uses: decide-single-kent/decide-single-kent/.github/workflows/django.yml@master
+    secrets: 
+      CODACY_PROJECT_TOKEN: ${{secrets.CODACY_PROJECT_TOKEN}}
+     
+  release:
+    needs: buildTest
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+      - name: Release
+        uses: softprops/action-gh-release@v1


### PR DESCRIPTION
Added a file release.yml to do the release only at master, for control versions
Modified django.yml, deleted the part of release at epic and develop branches, and added a workflow call with the codacy token at this file (django.yml too)